### PR TITLE
#23/feat email send

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     annotationProcessor ("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation ("com.auth0:java-jwt:4.2.1")
+    implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/src/main/kotlin/com/example/authserver/controller/EmailController.kt
+++ b/src/main/kotlin/com/example/authserver/controller/EmailController.kt
@@ -1,0 +1,63 @@
+package com.example.authserver.controller
+
+import com.example.authserver.aop.ROLEChecker
+import com.example.authserver.aop.RoleCheck
+import com.example.authserver.dto.Response
+import com.example.authserver.jwt.AuthToken
+import com.example.authserver.mail.EmailService
+import com.example.authserver.service.UserService
+import org.jetbrains.annotations.NotNull
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.server.reactive.ServerHttpRequest
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/email")
+class EmailController(
+    private val emailsService : EmailService,
+    private val userService: UserService
+) {
+
+    private val log = LoggerFactory.getLogger(EmailController::class.java)
+
+    @PostMapping("/valid")
+    suspend fun validEmailHandler(
+        @RequestHeader("X-Authorization-email") email : String
+    ) : Response{
+        log.info("send valid email start : [${email}]")
+        emailsService.sendIsValidEmail(email)
+        return Response(
+            code = 2000,
+            message = "이메일 전송 완료되었습니다",
+            data = null
+        )
+    }
+
+    @PostMapping("/check")
+    suspend fun checkEmailCode(
+        @ROLEChecker("READY") role : String,
+        @RequestBody requestCode: RequestCode,
+        @RequestHeader("X-Authorization-email") email : String
+    ) :Response {
+        log.info("email code valid")
+        emailsService.checkEmailCodeRedis(email, requestCode.code)
+        val response = userService.changeRole(email, "USER")
+        return Response(
+            code = 2010,
+            message = "이메일 인증이 완료되었습니다",
+            data = response
+        )
+    }
+}
+
+data class RequestEmail(
+    @NotNull
+    val email : String,
+)
+
+data class RequestCode(
+    @NotNull
+    val code : String,
+)

--- a/src/main/kotlin/com/example/authserver/controller/UserController.kt
+++ b/src/main/kotlin/com/example/authserver/controller/UserController.kt
@@ -1,7 +1,6 @@
 package com.example.authserver.controller
 
 import com.example.authserver.aop.ROLEChecker
-import com.example.authserver.aop.RoleCheck
 import com.example.authserver.dto.RequestLogin
 import com.example.authserver.dto.Response
 import com.example.authserver.jwt.AuthToken
@@ -9,7 +8,6 @@ import com.example.authserver.service.UserService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.*
-import reactor.core.publisher.Mono
 
 @RestController
 @RequestMapping("/api/user")
@@ -32,7 +30,6 @@ class UserController(
     @GetMapping("/me")
     suspend fun getMeHandler(
         @AuthToken token: String,
-        @ROLEChecker("USER") role: String,
     ): Response {
         return Response(
             code = 2000,

--- a/src/main/kotlin/com/example/authserver/dto/LoginDto.kt
+++ b/src/main/kotlin/com/example/authserver/dto/LoginDto.kt
@@ -12,5 +12,5 @@ data class ResponseLogin(
     val userId : Long,
     val accessToken : String? = null,
     val refreshToken : String? = null,
-    val role : String
+    val role : String,
 )

--- a/src/main/kotlin/com/example/authserver/dto/Response.kt
+++ b/src/main/kotlin/com/example/authserver/dto/Response.kt
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 data class Response(
     val code : Int,
     val message : String,
-    val data : Any,
+    val data : Any? = null,
 )
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -28,4 +28,8 @@ data class ResponseUser(
     )
 }
 
-
+data class ResponseCheckEmail(
+    val accessToken : String,
+    val refreshToken : String,
+    val userId : Long,
+)

--- a/src/main/kotlin/com/example/authserver/exception/CustomException.kt
+++ b/src/main/kotlin/com/example/authserver/exception/CustomException.kt
@@ -40,3 +40,15 @@ data class InvalidRoleException(
 data class InvalidVertificationException(
     override val message : String
 ) : CustomException(401, message = message)
+
+data class EmailSendException(
+    val errorCode : ErrorCode = ErrorCode.FAILED_SEND_EMAIL
+) : CustomException(errorCode.code, errorCode.message)
+
+data class NotMatchEmailCodeException(
+    val errorCode: ErrorCode = ErrorCode.NOT_MATCH_EMAILCODE
+) : CustomException(errorCode.code, errorCode.message)
+
+data class AlreadyStateRoleException(
+    val errorCode : ErrorCode = ErrorCode.ALREADY_STATE_ROLE
+) : CustomException(errorCode.code, errorCode.message)

--- a/src/main/kotlin/com/example/authserver/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/authserver/exception/ErrorCode.kt
@@ -5,16 +5,20 @@ enum class ErrorCode(
     val message : String
 ) {
     //login
-    EXIST_USER(409, "유저가 존재합니다."),
-    NOT_FOUND_USERNAME(404, "유저 이름이 입력되지 않았습니다"),
-    NOT_MATCH_PASSWORD(400, "패스워드가 일치하지 않습니다."),
+    EXIST_USER(4090, "유저가 존재합니다."),
+    NOT_FOUND_USERNAME(4040, "유저 이름이 입력되지 않았습니다"),
+    NOT_MATCH_PASSWORD(4000, "패스워드가 일치하지 않습니다."),
 
     //jwt
-    NOT_FOUND_TOKEN(404, "토큰이 존재하지 않습니다"),
-    INVALID_TOKEN(401, "검증되지 않은 토큰입니다."),
-    EXPIRED_TOKEN(401, "토큰이 만료되었습니다."),
+    NOT_FOUND_TOKEN(4040, "토큰이 존재하지 않습니다"),
+    INVALID_TOKEN(4010, "검증되지 않은 토큰입니다."),
+    EXPIRED_TOKEN(4010, "토큰이 만료되었습니다."),
 
     //header
-    NOT_FOUND_ROLE(404, "헤더에서 role이 발견되지 않았습니다"),
-    INVALID_ROLE(401, "권한이 없습니다")
+    NOT_FOUND_ROLE(4040, "헤더에서 role이 발견되지 않았습니다"),
+    INVALID_ROLE(4010, "권한이 없습니다"),
+
+    FAILED_SEND_EMAIL(5020, "이메일 전송에 실패했습니다"),
+    NOT_MATCH_EMAILCODE(4010, "이메일 코드가 일치하지 않습니다"),
+    ALREADY_STATE_ROLE(4090, "이미 권한이 중복입니다")
 }

--- a/src/main/kotlin/com/example/authserver/mail/EmailService.kt
+++ b/src/main/kotlin/com/example/authserver/mail/EmailService.kt
@@ -1,0 +1,9 @@
+package com.example.authserver.mail
+
+import org.springframework.stereotype.Service
+
+@Service
+interface EmailService {
+
+    fun sendSimpMessage(to : String, subject : String, text : String)
+}

--- a/src/main/kotlin/com/example/authserver/mail/EmailService.kt
+++ b/src/main/kotlin/com/example/authserver/mail/EmailService.kt
@@ -5,5 +5,9 @@ import org.springframework.stereotype.Service
 @Service
 interface EmailService {
 
-    fun sendSimpMessage(to : String, subject : String, text : String)
+    suspend fun sendSimpMessage(to : String, subject : String, text : String)
+    suspend fun sendEmailCodeRedis(key : String, value : String)
+    suspend fun checkEmailCodeRedis(email : String, code : String)
+    suspend fun sendIsValidEmail(email: String): Unit
+
 }

--- a/src/main/kotlin/com/example/authserver/mail/EmailServiceImpl.kt
+++ b/src/main/kotlin/com/example/authserver/mail/EmailServiceImpl.kt
@@ -1,0 +1,23 @@
+package com.example.authserver.mail
+
+import org.slf4j.LoggerFactory
+import org.springframework.mail.SimpleMailMessage
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.stereotype.Component
+
+@Component
+class EmailServiceImpl(
+    private val emailSender : JavaMailSender
+) : EmailService{
+
+    private val log = LoggerFactory.getLogger(EmailServiceImpl::class.java
+    )
+    override fun sendSimpMessage(to : String, subject : String, text : String) {
+        val message = SimpleMailMessage()
+        message.from = ("noreply@authserver.com")
+        message.setTo(to)
+        message.subject = subject
+        message.text = text
+        emailSender.send(message)
+    }
+}

--- a/src/main/kotlin/com/example/authserver/mail/EmailServiceImpl.kt
+++ b/src/main/kotlin/com/example/authserver/mail/EmailServiceImpl.kt
@@ -1,23 +1,73 @@
 package com.example.authserver.mail
 
+import com.example.authserver.exception.EmailSendException
+import com.example.authserver.exception.NotMatchEmailCodeException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import org.slf4j.LoggerFactory
 import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import kotlin.coroutines.cancellation.CancellationException
 
 @Component
 class EmailServiceImpl(
-    private val emailSender : JavaMailSender
+    private val emailSender : JavaMailSender,
+    private val redisEmailCodeStore: RedisEmailCodeStore,
 ) : EmailService{
 
     private val log = LoggerFactory.getLogger(EmailServiceImpl::class.java
     )
-    override fun sendSimpMessage(to : String, subject : String, text : String) {
-        val message = SimpleMailMessage()
-        message.from = ("noreply@authserver.com")
-        message.setTo(to)
-        message.subject = subject
-        message.text = text
-        emailSender.send(message)
+    override suspend fun sendSimpMessage(to : String, subject : String, text : String) {
+        try {
+            val message = SimpleMailMessage()
+            message.from = ("noreply@authserver.com")
+            message.setTo(to)
+            message.subject = subject
+            message.text = text
+            emailSender.send(message)
+        }catch (e : Throwable) {
+            throw CancellationException()
+        }
+
+    }
+
+
+    override suspend fun sendEmailCodeRedis(key: String, value: String) {
+        try {redisEmailCodeStore.push(key, value)}
+        catch(e : Throwable) {
+            throw CancellationException()
+        }
+    }
+
+    @Transactional(readOnly = true)
+    override suspend fun checkEmailCodeRedis(key: String, value : String) {
+        val code = redisEmailCodeStore.getAwaitAndExpired(key)
+        if (value != code)
+            throw NotMatchEmailCodeException()
+    }
+
+    override suspend fun sendIsValidEmail(email: String): Unit = coroutineScope {
+        val emailCode = UniqueCodeGenerator.generateUniqueCode(System.currentTimeMillis(), email)
+        try{
+            val emailSendFlag = async {
+                sendSimpMessage(
+                    email,
+                    "auth-server-code",
+                    emailCode
+                )
+                true
+            }
+            val redisFlag = async {
+                sendEmailCodeRedis(email, emailCode)
+                true
+            }
+            awaitAll(emailSendFlag, redisFlag)
+
+        }catch (e : Throwable) {
+            throw EmailSendException()
+        }
     }
 }

--- a/src/main/kotlin/com/example/authserver/mail/MailConfig.kt
+++ b/src/main/kotlin/com/example/authserver/mail/MailConfig.kt
@@ -1,6 +1,7 @@
 package com.example.authserver.mail
 
 import com.example.authserver.properties.MAILProperties
+import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.mail.javamail.JavaMailSender
@@ -12,6 +13,7 @@ class MailConfig(
     private val mailProperties : MAILProperties
 ) {
 
+    private val log = LoggerFactory.getLogger(MailConfig::class.java)
     @Bean
     fun getJavaMailSender() : JavaMailSender{
         val mailSender = JavaMailSenderImpl()

--- a/src/main/kotlin/com/example/authserver/mail/MailConfig.kt
+++ b/src/main/kotlin/com/example/authserver/mail/MailConfig.kt
@@ -1,0 +1,33 @@
+package com.example.authserver.mail
+
+import com.example.authserver.properties.MAILProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.JavaMailSenderImpl
+
+
+@Configuration
+class MailConfig(
+    private val mailProperties : MAILProperties
+) {
+
+    @Bean
+    fun getJavaMailSender() : JavaMailSender{
+        val mailSender = JavaMailSenderImpl()
+        with(mailProperties) {
+            mailSender.host = host
+            mailSender.port = port
+            mailSender.username = username
+            mailSender.password = password
+        }
+        val javaMailProperties = mailSender.javaMailProperties
+        javaMailProperties["mail.transport.protocol"] = "smtp"
+        javaMailProperties["mail.smtp.auth"] = "true"
+        javaMailProperties["mail.smtp.starttls.enable"] = "true"
+        javaMailProperties["mail.debug"] = "true"
+
+        return mailSender
+
+    }
+}

--- a/src/main/kotlin/com/example/authserver/mail/RedisEmailCodeStore.kt
+++ b/src/main/kotlin/com/example/authserver/mail/RedisEmailCodeStore.kt
@@ -1,0 +1,31 @@
+package com.example.authserver.mail
+
+import com.example.authserver.exception.NotFoundTokenException
+import io.netty.util.Timeout
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.data.redis.core.getAndAwait
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+
+@Component
+@Transactional
+class RedisEmailCodeStore(
+    @Qualifier("stringReactiveRedisTemplate")
+    private val stringRedisTemplate : ReactiveRedisTemplate<String, String>
+) {
+    private val log = LoggerFactory.getLogger(RedisEmailCodeStore::class.java)
+
+    suspend fun push(key : String, value : String) {
+        log.info("email redis push key : [$key] value :  [$value]")
+        stringRedisTemplate.opsForValue().set(key, value).subscribe()
+        stringRedisTemplate.expire(key, Duration.ofMinutes(30L)).subscribe()
+    }
+
+    suspend fun getAwaitAndExpired(key : String) =
+        stringRedisTemplate.opsForValue().getAndAwait(key)
+            ?: throw NotFoundTokenException()
+
+}

--- a/src/main/kotlin/com/example/authserver/mail/UniqueCodeGenerator.kt
+++ b/src/main/kotlin/com/example/authserver/mail/UniqueCodeGenerator.kt
@@ -1,0 +1,20 @@
+package com.example.authserver.mail
+
+import kotlinx.coroutines.coroutineScope
+import org.slf4j.LoggerFactory
+import java.util.*
+
+object UniqueCodeGenerator {
+
+    private val encoder = Base64.getEncoder()
+    private val log = LoggerFactory.getLogger(UniqueCodeGenerator::class.java)
+
+    suspend fun generateUniqueCode(time : Long, email : String) = coroutineScope{
+        val timeLast4 = time.toString().takeLast(4)
+        val cutEmail = email.substringBefore("@")
+        val encodedEmail = encoder.encodeToString(cutEmail.toByteArray())
+        val code = timeLast4 + encodedEmail
+        log.info("generate unique code : $code")
+        code
+    }
+}

--- a/src/main/kotlin/com/example/authserver/properties/MAILProperties.kt
+++ b/src/main/kotlin/com/example/authserver/properties/MAILProperties.kt
@@ -1,0 +1,11 @@
+package com.example.authserver.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "mail")
+data class MAILProperties (
+    val host : String,
+    val port : Int,
+    val username : String,
+    val password : String,
+)

--- a/src/main/kotlin/com/example/authserver/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/example/authserver/redis/RedisConfig.kt
@@ -20,7 +20,16 @@ class RedisConfig(
     private val redisProperties: RedisProperties
 ) {
 
-
+    @Bean(name = ["stringReactiveRedisTemplate"])
+    fun stringReactiveRedisTemplate(factory: LettuceConnectionFactory) : ReactiveRedisTemplate<String, String> {
+        val keySerializer = StringRedisSerializer()
+        val valueSerializer = StringRedisSerializer()
+        val builder: RedisSerializationContextBuilder<String, String> =
+            RedisSerializationContext.newSerializationContext<String, String>(keySerializer)
+        val context: RedisSerializationContext<String, String> =
+            builder.value(valueSerializer).build()
+        return ReactiveRedisTemplate(factory, context)
+    }
     @Bean
     fun reactiveRedisTemplate(factory : LettuceConnectionFactory) : ReactiveRedisTemplate<String, UserRedis> {
         val keySerializer = StringRedisSerializer()

--- a/src/main/kotlin/com/example/authserver/service/UserService.kt
+++ b/src/main/kotlin/com/example/authserver/service/UserService.kt
@@ -1,6 +1,7 @@
 package com.example.authserver.service
 
 import com.example.authserver.dto.RequestLogin
+import com.example.authserver.dto.ResponseCheckEmail
 import com.example.authserver.dto.ResponseLogin
 import com.example.authserver.redis.UserRedis
 import com.example.authserver.redis.UserRedisDto
@@ -13,4 +14,5 @@ interface UserService {
     suspend fun signIn(requestLogin : RequestLogin) : ResponseLogin
     suspend fun getToken(token : String) : UserRedis
     suspend fun getUserByToken(accessToken : String) : UserRedisDto?
+    suspend fun changeRole(email: String, role: String): ResponseCheckEmail
 }

--- a/src/test/kotlin/com/example/authserver/AuthServerApplicationTests.kt
+++ b/src/test/kotlin/com/example/authserver/AuthServerApplicationTests.kt
@@ -8,6 +8,8 @@ class AuthServerApplicationTests {
 
     @Test
     internal fun contextLoads() {
+        val currentTimeMillis = System.currentTimeMillis()
+        println(currentTimeMillis)
     }
 
 }


### PR DESCRIPTION
- #23 

유저 이메일 등록 시, 해당 이메일이 유효한지 검사하는 로직 추가


[구현]
개인 email stmp 에 연결하여 구현.

이메일이 전송되면 redis 에 해당 코드값 저장.  (유효기간 30분)
이메일이 전송이 안되거나 redis 에서 값이 저장이 안되면 rollback

30분 안에 코드 입력하여 redis에서 값 확인

usecase
1. 회원가입 후 바로 등록 
2. 회원가입 후 로그인 한 후, 이메일 검증

